### PR TITLE
Docs Edit: Adjust network modes so they are not falsely parsed as schema properties

### DIFF
--- a/provider/cmd/pulumi-resource-libvirt/schema.json
+++ b/provider/cmd/pulumi-resource-libvirt/schema.json
@@ -1142,7 +1142,7 @@
                 },
                 "mode": {
                     "type": "string",
-                    "description": "One of:\n"
+                    "description": "One of:\n- \"none\": the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN.\n- \"nat\": it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other.\n- \"route\": this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network.\n- \"open\": similar to `route`, but no firewall rules are added.\n- \"bridge\": use a pre-existing host bridge. The guests will effectively be\ndirectly connected to the physical network (i.e. their IP addresses will\nall be on the subnet of the physical network, and there will be no\nrestrictions on inbound or outbound connections). The `bridge` network\nattribute is mandatory in this case.\n"
                 },
                 "mtu": {
                     "type": "integer",
@@ -1206,7 +1206,7 @@
                 },
                 "mode": {
                     "type": "string",
-                    "description": "One of:\n",
+                    "description": "One of:\n- \"none\": the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN.\n- \"nat\": it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other.\n- \"route\": this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network.\n- \"open\": similar to `route`, but no firewall rules are added.\n- \"bridge\": use a pre-existing host bridge. The guests will effectively be\ndirectly connected to the physical network (i.e. their IP addresses will\nall be on the subnet of the physical network, and there will be no\nrestrictions on inbound or outbound connections). The `bridge` network\nattribute is mandatory in this case.\n",
                     "willReplaceOnChanges": true
                 },
                 "mtu": {
@@ -1269,7 +1269,7 @@
                     },
                     "mode": {
                         "type": "string",
-                        "description": "One of:\n",
+                        "description": "One of:\n- \"none\": the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN.\n- \"nat\": it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other.\n- \"route\": this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network.\n- \"open\": similar to `route`, but no firewall rules are added.\n- \"bridge\": use a pre-existing host bridge. The guests will effectively be\ndirectly connected to the physical network (i.e. their IP addresses will\nall be on the subnet of the physical network, and there will be no\nrestrictions on inbound or outbound connections). The `bridge` network\nattribute is mandatory in this case.\n",
                         "willReplaceOnChanges": true
                     },
                     "mtu": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"unicode"
 
 	// embed is used to store bridge-metadata.json in the compiled binary
@@ -179,15 +178,11 @@ func docRuleEdits(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
 	return append(defaults, tfbridge.DocsEdit{
 		Path: "network.markdown",
 		Edit: func(_ string, content []byte) ([]byte, error) {
-			matches := networkModesRegexp.FindAllString(string(content), -1)
-			for _, match := range matches {
-				after := strings.ReplaceAll(match, "`", "\"")
-				content = bytes.ReplaceAll(content,
-					[]byte(match),
-					[]byte(after),
-				)
-			}
-			return content, nil
+			return networkModesRegexp.ReplaceAllFunc(content,
+				func(src []byte) []byte {
+					return bytes.ReplaceAll(src,
+						[]byte("`"), []byte(`"`))
+				}), nil
 		},
 	})
 }

--- a/sdk/dotnet/Network.cs
+++ b/sdk/dotnet/Network.cs
@@ -62,6 +62,23 @@ namespace Pulumi.Libvirt
 
         /// <summary>
         /// One of:
+        /// - "none": the guests can talk to each other and the host OS, but cannot reach
+        /// any other machines on the LAN.
+        /// - "nat": it is the default network mode. This is a configuration that
+        /// allows guest OS to get outbound connectivity regardless of whether the host
+        /// uses ethernet, wireless, dialup, or VPN networking without requiring any
+        /// specific admin configuration. In the absence of host networking, it at
+        /// least allows guests to talk directly to each other.
+        /// - "route": this is a variant on the default network which routes traffic from
+        /// the virtual network to the LAN **without applying any NAT**. It requires that
+        /// the IP address range be pre-configured in the routing tables of the router
+        /// on the host network.
+        /// - "open": similar to `route`, but no firewall rules are added.
+        /// - "bridge": use a pre-existing host bridge. The guests will effectively be
+        /// directly connected to the physical network (i.e. their IP addresses will
+        /// all be on the subnet of the physical network, and there will be no
+        /// restrictions on inbound or outbound connections). The `bridge` network
+        /// attribute is mandatory in this case.
         /// </summary>
         [Output("mode")]
         public Output<string?> Mode { get; private set; } = null!;
@@ -189,6 +206,23 @@ namespace Pulumi.Libvirt
 
         /// <summary>
         /// One of:
+        /// - "none": the guests can talk to each other and the host OS, but cannot reach
+        /// any other machines on the LAN.
+        /// - "nat": it is the default network mode. This is a configuration that
+        /// allows guest OS to get outbound connectivity regardless of whether the host
+        /// uses ethernet, wireless, dialup, or VPN networking without requiring any
+        /// specific admin configuration. In the absence of host networking, it at
+        /// least allows guests to talk directly to each other.
+        /// - "route": this is a variant on the default network which routes traffic from
+        /// the virtual network to the LAN **without applying any NAT**. It requires that
+        /// the IP address range be pre-configured in the routing tables of the router
+        /// on the host network.
+        /// - "open": similar to `route`, but no firewall rules are added.
+        /// - "bridge": use a pre-existing host bridge. The guests will effectively be
+        /// directly connected to the physical network (i.e. their IP addresses will
+        /// all be on the subnet of the physical network, and there will be no
+        /// restrictions on inbound or outbound connections). The `bridge` network
+        /// attribute is mandatory in this case.
         /// </summary>
         [Input("mode")]
         public Input<string>? Mode { get; set; }
@@ -284,6 +318,23 @@ namespace Pulumi.Libvirt
 
         /// <summary>
         /// One of:
+        /// - "none": the guests can talk to each other and the host OS, but cannot reach
+        /// any other machines on the LAN.
+        /// - "nat": it is the default network mode. This is a configuration that
+        /// allows guest OS to get outbound connectivity regardless of whether the host
+        /// uses ethernet, wireless, dialup, or VPN networking without requiring any
+        /// specific admin configuration. In the absence of host networking, it at
+        /// least allows guests to talk directly to each other.
+        /// - "route": this is a variant on the default network which routes traffic from
+        /// the virtual network to the LAN **without applying any NAT**. It requires that
+        /// the IP address range be pre-configured in the routing tables of the router
+        /// on the host network.
+        /// - "open": similar to `route`, but no firewall rules are added.
+        /// - "bridge": use a pre-existing host bridge. The guests will effectively be
+        /// directly connected to the physical network (i.e. their IP addresses will
+        /// all be on the subnet of the physical network, and there will be no
+        /// restrictions on inbound or outbound connections). The `bridge` network
+        /// attribute is mandatory in this case.
         /// </summary>
         [Input("mode")]
         public Input<string>? Mode { get; set; }

--- a/sdk/go/libvirt/network.go
+++ b/sdk/go/libvirt/network.go
@@ -37,6 +37,23 @@ type Network struct {
 	// The domain used by the DNS server.
 	Domain pulumi.StringPtrOutput `pulumi:"domain"`
 	// One of:
+	// - "none": the guests can talk to each other and the host OS, but cannot reach
+	//   any other machines on the LAN.
+	// - "nat": it is the default network mode. This is a configuration that
+	//   allows guest OS to get outbound connectivity regardless of whether the host
+	//   uses ethernet, wireless, dialup, or VPN networking without requiring any
+	//   specific admin configuration. In the absence of host networking, it at
+	//   least allows guests to talk directly to each other.
+	// - "route": this is a variant on the default network which routes traffic from
+	//   the virtual network to the LAN **without applying any NAT**. It requires that
+	//   the IP address range be pre-configured in the routing tables of the router
+	//   on the host network.
+	// - "open": similar to `route`, but no firewall rules are added.
+	// - "bridge": use a pre-existing host bridge. The guests will effectively be
+	//   directly connected to the physical network (i.e. their IP addresses will
+	//   all be on the subnet of the physical network, and there will be no
+	//   restrictions on inbound or outbound connections). The `bridge` network
+	//   attribute is mandatory in this case.
 	Mode pulumi.StringPtrOutput `pulumi:"mode"`
 	// The MTU to set for the underlying network interfaces. When
 	// not supplied, libvirt will use the default for the interface, usually 1500.
@@ -102,6 +119,23 @@ type networkState struct {
 	// The domain used by the DNS server.
 	Domain *string `pulumi:"domain"`
 	// One of:
+	// - "none": the guests can talk to each other and the host OS, but cannot reach
+	//   any other machines on the LAN.
+	// - "nat": it is the default network mode. This is a configuration that
+	//   allows guest OS to get outbound connectivity regardless of whether the host
+	//   uses ethernet, wireless, dialup, or VPN networking without requiring any
+	//   specific admin configuration. In the absence of host networking, it at
+	//   least allows guests to talk directly to each other.
+	// - "route": this is a variant on the default network which routes traffic from
+	//   the virtual network to the LAN **without applying any NAT**. It requires that
+	//   the IP address range be pre-configured in the routing tables of the router
+	//   on the host network.
+	// - "open": similar to `route`, but no firewall rules are added.
+	// - "bridge": use a pre-existing host bridge. The guests will effectively be
+	//   directly connected to the physical network (i.e. their IP addresses will
+	//   all be on the subnet of the physical network, and there will be no
+	//   restrictions on inbound or outbound connections). The `bridge` network
+	//   attribute is mandatory in this case.
 	Mode *string `pulumi:"mode"`
 	// The MTU to set for the underlying network interfaces. When
 	// not supplied, libvirt will use the default for the interface, usually 1500.
@@ -138,6 +172,23 @@ type NetworkState struct {
 	// The domain used by the DNS server.
 	Domain pulumi.StringPtrInput
 	// One of:
+	// - "none": the guests can talk to each other and the host OS, but cannot reach
+	//   any other machines on the LAN.
+	// - "nat": it is the default network mode. This is a configuration that
+	//   allows guest OS to get outbound connectivity regardless of whether the host
+	//   uses ethernet, wireless, dialup, or VPN networking without requiring any
+	//   specific admin configuration. In the absence of host networking, it at
+	//   least allows guests to talk directly to each other.
+	// - "route": this is a variant on the default network which routes traffic from
+	//   the virtual network to the LAN **without applying any NAT**. It requires that
+	//   the IP address range be pre-configured in the routing tables of the router
+	//   on the host network.
+	// - "open": similar to `route`, but no firewall rules are added.
+	// - "bridge": use a pre-existing host bridge. The guests will effectively be
+	//   directly connected to the physical network (i.e. their IP addresses will
+	//   all be on the subnet of the physical network, and there will be no
+	//   restrictions on inbound or outbound connections). The `bridge` network
+	//   attribute is mandatory in this case.
 	Mode pulumi.StringPtrInput
 	// The MTU to set for the underlying network interfaces. When
 	// not supplied, libvirt will use the default for the interface, usually 1500.
@@ -178,6 +229,23 @@ type networkArgs struct {
 	// The domain used by the DNS server.
 	Domain *string `pulumi:"domain"`
 	// One of:
+	// - "none": the guests can talk to each other and the host OS, but cannot reach
+	//   any other machines on the LAN.
+	// - "nat": it is the default network mode. This is a configuration that
+	//   allows guest OS to get outbound connectivity regardless of whether the host
+	//   uses ethernet, wireless, dialup, or VPN networking without requiring any
+	//   specific admin configuration. In the absence of host networking, it at
+	//   least allows guests to talk directly to each other.
+	// - "route": this is a variant on the default network which routes traffic from
+	//   the virtual network to the LAN **without applying any NAT**. It requires that
+	//   the IP address range be pre-configured in the routing tables of the router
+	//   on the host network.
+	// - "open": similar to `route`, but no firewall rules are added.
+	// - "bridge": use a pre-existing host bridge. The guests will effectively be
+	//   directly connected to the physical network (i.e. their IP addresses will
+	//   all be on the subnet of the physical network, and there will be no
+	//   restrictions on inbound or outbound connections). The `bridge` network
+	//   attribute is mandatory in this case.
 	Mode *string `pulumi:"mode"`
 	// The MTU to set for the underlying network interfaces. When
 	// not supplied, libvirt will use the default for the interface, usually 1500.
@@ -215,6 +283,23 @@ type NetworkArgs struct {
 	// The domain used by the DNS server.
 	Domain pulumi.StringPtrInput
 	// One of:
+	// - "none": the guests can talk to each other and the host OS, but cannot reach
+	//   any other machines on the LAN.
+	// - "nat": it is the default network mode. This is a configuration that
+	//   allows guest OS to get outbound connectivity regardless of whether the host
+	//   uses ethernet, wireless, dialup, or VPN networking without requiring any
+	//   specific admin configuration. In the absence of host networking, it at
+	//   least allows guests to talk directly to each other.
+	// - "route": this is a variant on the default network which routes traffic from
+	//   the virtual network to the LAN **without applying any NAT**. It requires that
+	//   the IP address range be pre-configured in the routing tables of the router
+	//   on the host network.
+	// - "open": similar to `route`, but no firewall rules are added.
+	// - "bridge": use a pre-existing host bridge. The guests will effectively be
+	//   directly connected to the physical network (i.e. their IP addresses will
+	//   all be on the subnet of the physical network, and there will be no
+	//   restrictions on inbound or outbound connections). The `bridge` network
+	//   attribute is mandatory in this case.
 	Mode pulumi.StringPtrInput
 	// The MTU to set for the underlying network interfaces. When
 	// not supplied, libvirt will use the default for the interface, usually 1500.
@@ -358,6 +443,23 @@ func (o NetworkOutput) Domain() pulumi.StringPtrOutput {
 }
 
 // One of:
+//   - "none": the guests can talk to each other and the host OS, but cannot reach
+//     any other machines on the LAN.
+//   - "nat": it is the default network mode. This is a configuration that
+//     allows guest OS to get outbound connectivity regardless of whether the host
+//     uses ethernet, wireless, dialup, or VPN networking without requiring any
+//     specific admin configuration. In the absence of host networking, it at
+//     least allows guests to talk directly to each other.
+//   - "route": this is a variant on the default network which routes traffic from
+//     the virtual network to the LAN **without applying any NAT**. It requires that
+//     the IP address range be pre-configured in the routing tables of the router
+//     on the host network.
+//   - "open": similar to `route`, but no firewall rules are added.
+//   - "bridge": use a pre-existing host bridge. The guests will effectively be
+//     directly connected to the physical network (i.e. their IP addresses will
+//     all be on the subnet of the physical network, and there will be no
+//     restrictions on inbound or outbound connections). The `bridge` network
+//     attribute is mandatory in this case.
 func (o NetworkOutput) Mode() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Network) pulumi.StringPtrOutput { return v.Mode }).(pulumi.StringPtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/libvirt/Network.java
+++ b/sdk/java/src/main/java/com/pulumi/libvirt/Network.java
@@ -129,6 +129,23 @@ public class Network extends com.pulumi.resources.CustomResource {
     }
     /**
      * One of:
+     * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+     *   any other machines on the LAN.
+     * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+     *   allows guest OS to get outbound connectivity regardless of whether the host
+     *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+     *   specific admin configuration. In the absence of host networking, it at
+     *   least allows guests to talk directly to each other.
+     * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+     *   the virtual network to the LAN **without applying any NAT**. It requires that
+     *   the IP address range be pre-configured in the routing tables of the router
+     *   on the host network.
+     * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+     * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+     *   directly connected to the physical network (i.e. their IP addresses will
+     *   all be on the subnet of the physical network, and there will be no
+     *   restrictions on inbound or outbound connections). The `bridge` network
+     *   attribute is mandatory in this case.
      * 
      */
     @Export(name="mode", refs={String.class}, tree="[0]")
@@ -136,6 +153,23 @@ public class Network extends com.pulumi.resources.CustomResource {
 
     /**
      * @return One of:
+     * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+     *   any other machines on the LAN.
+     * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+     *   allows guest OS to get outbound connectivity regardless of whether the host
+     *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+     *   specific admin configuration. In the absence of host networking, it at
+     *   least allows guests to talk directly to each other.
+     * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+     *   the virtual network to the LAN **without applying any NAT**. It requires that
+     *   the IP address range be pre-configured in the routing tables of the router
+     *   on the host network.
+     * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+     * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+     *   directly connected to the physical network (i.e. their IP addresses will
+     *   all be on the subnet of the physical network, and there will be no
+     *   restrictions on inbound or outbound connections). The `bridge` network
+     *   attribute is mandatory in this case.
      * 
      */
     public Output<Optional<String>> mode() {

--- a/sdk/java/src/main/java/com/pulumi/libvirt/NetworkArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/libvirt/NetworkArgs.java
@@ -130,6 +130,23 @@ public final class NetworkArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * One of:
+     * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+     *   any other machines on the LAN.
+     * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+     *   allows guest OS to get outbound connectivity regardless of whether the host
+     *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+     *   specific admin configuration. In the absence of host networking, it at
+     *   least allows guests to talk directly to each other.
+     * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+     *   the virtual network to the LAN **without applying any NAT**. It requires that
+     *   the IP address range be pre-configured in the routing tables of the router
+     *   on the host network.
+     * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+     * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+     *   directly connected to the physical network (i.e. their IP addresses will
+     *   all be on the subnet of the physical network, and there will be no
+     *   restrictions on inbound or outbound connections). The `bridge` network
+     *   attribute is mandatory in this case.
      * 
      */
     @Import(name="mode")
@@ -137,6 +154,23 @@ public final class NetworkArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * @return One of:
+     * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+     *   any other machines on the LAN.
+     * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+     *   allows guest OS to get outbound connectivity regardless of whether the host
+     *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+     *   specific admin configuration. In the absence of host networking, it at
+     *   least allows guests to talk directly to each other.
+     * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+     *   the virtual network to the LAN **without applying any NAT**. It requires that
+     *   the IP address range be pre-configured in the routing tables of the router
+     *   on the host network.
+     * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+     * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+     *   directly connected to the physical network (i.e. their IP addresses will
+     *   all be on the subnet of the physical network, and there will be no
+     *   restrictions on inbound or outbound connections). The `bridge` network
+     *   attribute is mandatory in this case.
      * 
      */
     public Optional<Output<String>> mode() {
@@ -394,6 +428,23 @@ public final class NetworkArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param mode One of:
+         * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+         *   any other machines on the LAN.
+         * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+         *   allows guest OS to get outbound connectivity regardless of whether the host
+         *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+         *   specific admin configuration. In the absence of host networking, it at
+         *   least allows guests to talk directly to each other.
+         * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+         *   the virtual network to the LAN **without applying any NAT**. It requires that
+         *   the IP address range be pre-configured in the routing tables of the router
+         *   on the host network.
+         * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+         * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+         *   directly connected to the physical network (i.e. their IP addresses will
+         *   all be on the subnet of the physical network, and there will be no
+         *   restrictions on inbound or outbound connections). The `bridge` network
+         *   attribute is mandatory in this case.
          * 
          * @return builder
          * 
@@ -405,6 +456,23 @@ public final class NetworkArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param mode One of:
+         * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+         *   any other machines on the LAN.
+         * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+         *   allows guest OS to get outbound connectivity regardless of whether the host
+         *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+         *   specific admin configuration. In the absence of host networking, it at
+         *   least allows guests to talk directly to each other.
+         * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+         *   the virtual network to the LAN **without applying any NAT**. It requires that
+         *   the IP address range be pre-configured in the routing tables of the router
+         *   on the host network.
+         * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+         * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+         *   directly connected to the physical network (i.e. their IP addresses will
+         *   all be on the subnet of the physical network, and there will be no
+         *   restrictions on inbound or outbound connections). The `bridge` network
+         *   attribute is mandatory in this case.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/libvirt/inputs/NetworkState.java
+++ b/sdk/java/src/main/java/com/pulumi/libvirt/inputs/NetworkState.java
@@ -130,6 +130,23 @@ public final class NetworkState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * One of:
+     * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+     *   any other machines on the LAN.
+     * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+     *   allows guest OS to get outbound connectivity regardless of whether the host
+     *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+     *   specific admin configuration. In the absence of host networking, it at
+     *   least allows guests to talk directly to each other.
+     * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+     *   the virtual network to the LAN **without applying any NAT**. It requires that
+     *   the IP address range be pre-configured in the routing tables of the router
+     *   on the host network.
+     * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+     * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+     *   directly connected to the physical network (i.e. their IP addresses will
+     *   all be on the subnet of the physical network, and there will be no
+     *   restrictions on inbound or outbound connections). The `bridge` network
+     *   attribute is mandatory in this case.
      * 
      */
     @Import(name="mode")
@@ -137,6 +154,23 @@ public final class NetworkState extends com.pulumi.resources.ResourceArgs {
 
     /**
      * @return One of:
+     * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+     *   any other machines on the LAN.
+     * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+     *   allows guest OS to get outbound connectivity regardless of whether the host
+     *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+     *   specific admin configuration. In the absence of host networking, it at
+     *   least allows guests to talk directly to each other.
+     * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+     *   the virtual network to the LAN **without applying any NAT**. It requires that
+     *   the IP address range be pre-configured in the routing tables of the router
+     *   on the host network.
+     * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+     * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+     *   directly connected to the physical network (i.e. their IP addresses will
+     *   all be on the subnet of the physical network, and there will be no
+     *   restrictions on inbound or outbound connections). The `bridge` network
+     *   attribute is mandatory in this case.
      * 
      */
     public Optional<Output<String>> mode() {
@@ -394,6 +428,23 @@ public final class NetworkState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param mode One of:
+         * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+         *   any other machines on the LAN.
+         * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+         *   allows guest OS to get outbound connectivity regardless of whether the host
+         *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+         *   specific admin configuration. In the absence of host networking, it at
+         *   least allows guests to talk directly to each other.
+         * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+         *   the virtual network to the LAN **without applying any NAT**. It requires that
+         *   the IP address range be pre-configured in the routing tables of the router
+         *   on the host network.
+         * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+         * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+         *   directly connected to the physical network (i.e. their IP addresses will
+         *   all be on the subnet of the physical network, and there will be no
+         *   restrictions on inbound or outbound connections). The `bridge` network
+         *   attribute is mandatory in this case.
          * 
          * @return builder
          * 
@@ -405,6 +456,23 @@ public final class NetworkState extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param mode One of:
+         * - &#34;none&#34;: the guests can talk to each other and the host OS, but cannot reach
+         *   any other machines on the LAN.
+         * - &#34;nat&#34;: it is the default network mode. This is a configuration that
+         *   allows guest OS to get outbound connectivity regardless of whether the host
+         *   uses ethernet, wireless, dialup, or VPN networking without requiring any
+         *   specific admin configuration. In the absence of host networking, it at
+         *   least allows guests to talk directly to each other.
+         * - &#34;route&#34;: this is a variant on the default network which routes traffic from
+         *   the virtual network to the LAN **without applying any NAT**. It requires that
+         *   the IP address range be pre-configured in the routing tables of the router
+         *   on the host network.
+         * - &#34;open&#34;: similar to `route`, but no firewall rules are added.
+         * - &#34;bridge&#34;: use a pre-existing host bridge. The guests will effectively be
+         *   directly connected to the physical network (i.e. their IP addresses will
+         *   all be on the subnet of the physical network, and there will be no
+         *   restrictions on inbound or outbound connections). The `bridge` network
+         *   attribute is mandatory in this case.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/network.ts
+++ b/sdk/nodejs/network.ts
@@ -70,6 +70,23 @@ export class Network extends pulumi.CustomResource {
     public readonly domain!: pulumi.Output<string | undefined>;
     /**
      * One of:
+     * - "none": the guests can talk to each other and the host OS, but cannot reach
+     * any other machines on the LAN.
+     * - "nat": it is the default network mode. This is a configuration that
+     * allows guest OS to get outbound connectivity regardless of whether the host
+     * uses ethernet, wireless, dialup, or VPN networking without requiring any
+     * specific admin configuration. In the absence of host networking, it at
+     * least allows guests to talk directly to each other.
+     * - "route": this is a variant on the default network which routes traffic from
+     * the virtual network to the LAN **without applying any NAT**. It requires that
+     * the IP address range be pre-configured in the routing tables of the router
+     * on the host network.
+     * - "open": similar to `route`, but no firewall rules are added.
+     * - "bridge": use a pre-existing host bridge. The guests will effectively be
+     * directly connected to the physical network (i.e. their IP addresses will
+     * all be on the subnet of the physical network, and there will be no
+     * restrictions on inbound or outbound connections). The `bridge` network
+     * attribute is mandatory in this case.
      */
     public readonly mode!: pulumi.Output<string | undefined>;
     /**
@@ -171,6 +188,23 @@ export interface NetworkState {
     domain?: pulumi.Input<string>;
     /**
      * One of:
+     * - "none": the guests can talk to each other and the host OS, but cannot reach
+     * any other machines on the LAN.
+     * - "nat": it is the default network mode. This is a configuration that
+     * allows guest OS to get outbound connectivity regardless of whether the host
+     * uses ethernet, wireless, dialup, or VPN networking without requiring any
+     * specific admin configuration. In the absence of host networking, it at
+     * least allows guests to talk directly to each other.
+     * - "route": this is a variant on the default network which routes traffic from
+     * the virtual network to the LAN **without applying any NAT**. It requires that
+     * the IP address range be pre-configured in the routing tables of the router
+     * on the host network.
+     * - "open": similar to `route`, but no firewall rules are added.
+     * - "bridge": use a pre-existing host bridge. The guests will effectively be
+     * directly connected to the physical network (i.e. their IP addresses will
+     * all be on the subnet of the physical network, and there will be no
+     * restrictions on inbound or outbound connections). The `bridge` network
+     * attribute is mandatory in this case.
      */
     mode?: pulumi.Input<string>;
     /**
@@ -228,6 +262,23 @@ export interface NetworkArgs {
     domain?: pulumi.Input<string>;
     /**
      * One of:
+     * - "none": the guests can talk to each other and the host OS, but cannot reach
+     * any other machines on the LAN.
+     * - "nat": it is the default network mode. This is a configuration that
+     * allows guest OS to get outbound connectivity regardless of whether the host
+     * uses ethernet, wireless, dialup, or VPN networking without requiring any
+     * specific admin configuration. In the absence of host networking, it at
+     * least allows guests to talk directly to each other.
+     * - "route": this is a variant on the default network which routes traffic from
+     * the virtual network to the LAN **without applying any NAT**. It requires that
+     * the IP address range be pre-configured in the routing tables of the router
+     * on the host network.
+     * - "open": similar to `route`, but no firewall rules are added.
+     * - "bridge": use a pre-existing host bridge. The guests will effectively be
+     * directly connected to the physical network (i.e. their IP addresses will
+     * all be on the subnet of the physical network, and there will be no
+     * restrictions on inbound or outbound connections). The `bridge` network
+     * attribute is mandatory in this case.
      */
     mode?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_libvirt/network.py
+++ b/sdk/python/pulumi_libvirt/network.py
@@ -44,6 +44,23 @@ class NetworkArgs:
         :param pulumi.Input['NetworkDnsArgs'] dns: configuration of DNS specific settings for the network
         :param pulumi.Input[str] domain: The domain used by the DNS server.
         :param pulumi.Input[str] mode: One of:
+               - "none": the guests can talk to each other and the host OS, but cannot reach
+               any other machines on the LAN.
+               - "nat": it is the default network mode. This is a configuration that
+               allows guest OS to get outbound connectivity regardless of whether the host
+               uses ethernet, wireless, dialup, or VPN networking without requiring any
+               specific admin configuration. In the absence of host networking, it at
+               least allows guests to talk directly to each other.
+               - "route": this is a variant on the default network which routes traffic from
+               the virtual network to the LAN **without applying any NAT**. It requires that
+               the IP address range be pre-configured in the routing tables of the router
+               on the host network.
+               - "open": similar to `route`, but no firewall rules are added.
+               - "bridge": use a pre-existing host bridge. The guests will effectively be
+               directly connected to the physical network (i.e. their IP addresses will
+               all be on the subnet of the physical network, and there will be no
+               restrictions on inbound or outbound connections). The `bridge` network
+               attribute is mandatory in this case.
         :param pulumi.Input[int] mtu: The MTU to set for the underlying network interfaces. When
                not supplied, libvirt will use the default for the interface, usually 1500.
                Libvirt version 5.1 and greater will advertise this value to nodes via DHCP.
@@ -168,6 +185,23 @@ class NetworkArgs:
     def mode(self) -> Optional[pulumi.Input[str]]:
         """
         One of:
+        - "none": the guests can talk to each other and the host OS, but cannot reach
+        any other machines on the LAN.
+        - "nat": it is the default network mode. This is a configuration that
+        allows guest OS to get outbound connectivity regardless of whether the host
+        uses ethernet, wireless, dialup, or VPN networking without requiring any
+        specific admin configuration. In the absence of host networking, it at
+        least allows guests to talk directly to each other.
+        - "route": this is a variant on the default network which routes traffic from
+        the virtual network to the LAN **without applying any NAT**. It requires that
+        the IP address range be pre-configured in the routing tables of the router
+        on the host network.
+        - "open": similar to `route`, but no firewall rules are added.
+        - "bridge": use a pre-existing host bridge. The guests will effectively be
+        directly connected to the physical network (i.e. their IP addresses will
+        all be on the subnet of the physical network, and there will be no
+        restrictions on inbound or outbound connections). The `bridge` network
+        attribute is mandatory in this case.
         """
         return pulumi.get(self, "mode")
 
@@ -256,6 +290,23 @@ class _NetworkState:
         :param pulumi.Input['NetworkDnsArgs'] dns: configuration of DNS specific settings for the network
         :param pulumi.Input[str] domain: The domain used by the DNS server.
         :param pulumi.Input[str] mode: One of:
+               - "none": the guests can talk to each other and the host OS, but cannot reach
+               any other machines on the LAN.
+               - "nat": it is the default network mode. This is a configuration that
+               allows guest OS to get outbound connectivity regardless of whether the host
+               uses ethernet, wireless, dialup, or VPN networking without requiring any
+               specific admin configuration. In the absence of host networking, it at
+               least allows guests to talk directly to each other.
+               - "route": this is a variant on the default network which routes traffic from
+               the virtual network to the LAN **without applying any NAT**. It requires that
+               the IP address range be pre-configured in the routing tables of the router
+               on the host network.
+               - "open": similar to `route`, but no firewall rules are added.
+               - "bridge": use a pre-existing host bridge. The guests will effectively be
+               directly connected to the physical network (i.e. their IP addresses will
+               all be on the subnet of the physical network, and there will be no
+               restrictions on inbound or outbound connections). The `bridge` network
+               attribute is mandatory in this case.
         :param pulumi.Input[int] mtu: The MTU to set for the underlying network interfaces. When
                not supplied, libvirt will use the default for the interface, usually 1500.
                Libvirt version 5.1 and greater will advertise this value to nodes via DHCP.
@@ -380,6 +431,23 @@ class _NetworkState:
     def mode(self) -> Optional[pulumi.Input[str]]:
         """
         One of:
+        - "none": the guests can talk to each other and the host OS, but cannot reach
+        any other machines on the LAN.
+        - "nat": it is the default network mode. This is a configuration that
+        allows guest OS to get outbound connectivity regardless of whether the host
+        uses ethernet, wireless, dialup, or VPN networking without requiring any
+        specific admin configuration. In the absence of host networking, it at
+        least allows guests to talk directly to each other.
+        - "route": this is a variant on the default network which routes traffic from
+        the virtual network to the LAN **without applying any NAT**. It requires that
+        the IP address range be pre-configured in the routing tables of the router
+        on the host network.
+        - "open": similar to `route`, but no firewall rules are added.
+        - "bridge": use a pre-existing host bridge. The guests will effectively be
+        directly connected to the physical network (i.e. their IP addresses will
+        all be on the subnet of the physical network, and there will be no
+        restrictions on inbound or outbound connections). The `bridge` network
+        attribute is mandatory in this case.
         """
         return pulumi.get(self, "mode")
 
@@ -475,6 +543,23 @@ class Network(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['NetworkDnsArgs']] dns: configuration of DNS specific settings for the network
         :param pulumi.Input[str] domain: The domain used by the DNS server.
         :param pulumi.Input[str] mode: One of:
+               - "none": the guests can talk to each other and the host OS, but cannot reach
+               any other machines on the LAN.
+               - "nat": it is the default network mode. This is a configuration that
+               allows guest OS to get outbound connectivity regardless of whether the host
+               uses ethernet, wireless, dialup, or VPN networking without requiring any
+               specific admin configuration. In the absence of host networking, it at
+               least allows guests to talk directly to each other.
+               - "route": this is a variant on the default network which routes traffic from
+               the virtual network to the LAN **without applying any NAT**. It requires that
+               the IP address range be pre-configured in the routing tables of the router
+               on the host network.
+               - "open": similar to `route`, but no firewall rules are added.
+               - "bridge": use a pre-existing host bridge. The guests will effectively be
+               directly connected to the physical network (i.e. their IP addresses will
+               all be on the subnet of the physical network, and there will be no
+               restrictions on inbound or outbound connections). The `bridge` network
+               attribute is mandatory in this case.
         :param pulumi.Input[int] mtu: The MTU to set for the underlying network interfaces. When
                not supplied, libvirt will use the default for the interface, usually 1500.
                Libvirt version 5.1 and greater will advertise this value to nodes via DHCP.
@@ -584,6 +669,23 @@ class Network(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['NetworkDnsArgs']] dns: configuration of DNS specific settings for the network
         :param pulumi.Input[str] domain: The domain used by the DNS server.
         :param pulumi.Input[str] mode: One of:
+               - "none": the guests can talk to each other and the host OS, but cannot reach
+               any other machines on the LAN.
+               - "nat": it is the default network mode. This is a configuration that
+               allows guest OS to get outbound connectivity regardless of whether the host
+               uses ethernet, wireless, dialup, or VPN networking without requiring any
+               specific admin configuration. In the absence of host networking, it at
+               least allows guests to talk directly to each other.
+               - "route": this is a variant on the default network which routes traffic from
+               the virtual network to the LAN **without applying any NAT**. It requires that
+               the IP address range be pre-configured in the routing tables of the router
+               on the host network.
+               - "open": similar to `route`, but no firewall rules are added.
+               - "bridge": use a pre-existing host bridge. The guests will effectively be
+               directly connected to the physical network (i.e. their IP addresses will
+               all be on the subnet of the physical network, and there will be no
+               restrictions on inbound or outbound connections). The `bridge` network
+               attribute is mandatory in this case.
         :param pulumi.Input[int] mtu: The MTU to set for the underlying network interfaces. When
                not supplied, libvirt will use the default for the interface, usually 1500.
                Libvirt version 5.1 and greater will advertise this value to nodes via DHCP.
@@ -673,6 +775,23 @@ class Network(pulumi.CustomResource):
     def mode(self) -> pulumi.Output[Optional[str]]:
         """
         One of:
+        - "none": the guests can talk to each other and the host OS, but cannot reach
+        any other machines on the LAN.
+        - "nat": it is the default network mode. This is a configuration that
+        allows guest OS to get outbound connectivity regardless of whether the host
+        uses ethernet, wireless, dialup, or VPN networking without requiring any
+        specific admin configuration. In the absence of host networking, it at
+        least allows guests to talk directly to each other.
+        - "route": this is a variant on the default network which routes traffic from
+        the virtual network to the LAN **without applying any NAT**. It requires that
+        the IP address range be pre-configured in the routing tables of the router
+        on the host network.
+        - "open": similar to `route`, but no firewall rules are added.
+        - "bridge": use a pre-existing host bridge. The guests will effectively be
+        directly connected to the physical network (i.e. their IP addresses will
+        all be on the subnet of the physical network, and there will be no
+        restrictions on inbound or outbound connections). The `bridge` network
+        attribute is mandatory in this case.
         """
         return pulumi.get(self, "mode")
 


### PR DESCRIPTION
This is a provider-level fix for https://github.com/pulumi/pulumi-libvirt/issues/335.

Our docs parsing has no ability to differentiate between a schema property description such as

``* `property`: Description lorem ipsum``

and a value option describing a list of valid values for a property, such as

``* `value`: Can be of this value under condition foo``

when the content between the backticks is all lowercase, with no underscores.

Therefore, this new docsEditRule replaces the `` ` `` character with a `"` character for network.mode's value list, so they don't get cut off from the description field.

Alternatives include:

- Patching the upstream doc in question to similar effect (recommend against)
- Convince upstream to avoid using backticks (really not worth it IMO)
- Introduce more bridge-level regex parsing to discover these types of value lists - this is something worth exploring if we continue to see multiples of these, but as this verbiage is _not_ standardized, I think editing the docs via docsEditRule is a good solution to fix the docs.


- Add DocsEditRule to network.markdown to allow for rendering of network modes
- gen schema and sdks
