### PR TITLE
Add installation file

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -6,6 +6,7 @@ env:
 makeTemplate: bridged
 team: ecosystem
 pulumiConvert: 1
+registryDocs: true
 plugins:
   - name: terraform
     version: "1.0.16"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks
 
-build_sdks: build_nodejs build_python build_dotnet build_go build_java 
+build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
 
 install_go_sdk:
 
@@ -95,6 +95,10 @@ build_python: upstream
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
+
+# Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
+build_registry_docs:
+	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,203 @@
+---
+title: Libvirt Provider
+meta_desc: Provides an overview on how to configure the Pulumi Libvirt provider.
+layout: package
+---
+## Installation
+
+The libvirt provider is available as a package in all Pulumi languages:
+
+* JavaScript/TypeScript: [`@pulumi/libvirt`](https://www.npmjs.com/package/@pulumi/libvirt)
+* Python: [`pulumi-libvirt`](https://pypi.org/project/pulumi-libvirt/)
+* Go: [`github.com/pulumi/pulumi-libvirt/sdk/go/libvirt`](https://github.com/pulumi/pulumi-libvirt)
+* .NET: [`Pulumi.Libvirt`](https://www.nuget.org/packages/Pulumi.Libvirt)
+* Java: [`com.pulumi/libvirt`](https://central.sonatype.com/artifact/com.pulumi/libvirt)
+## Overview
+
+The Libvirt provider is used to interact with Linux
+[libvirt](https://libvirt.org) hypervisors.
+
+The provider needs to be configured with the proper connection information
+before it can be used.
+
+> **Note:** while libvirt can be used with several types of hypervisors, this
+provider focuses on [KVM](http://libvirt.org/drvqemu.html). Other drivers may not be
+working and haven't been tested.
+## The connection URI
+
+The provider understands [connection URIs](https://libvirt.org/uri.html). The supported transports are:
+
+* `tcp` (non-encrypted connection)
+* `unix` (UNIX domain socket)
+* `tls` (See [here](https://libvirt.org/kbase/tlscerts.html) for information how to setup certificates)
+* `ssh` (Secure shell)
+
+Unlike the original libvirt, the `ssh` transport is not implemented using the ssh command and therefore does not require `nc` (netcat) on the server side.
+
+Additionally, the `ssh` URI supports passwords using the `driver+ssh://[username:PASSWORD@][hostname][:port]/[path]?sshauth=ssh-password` syntax.
+
+As the provider does not use libvirt on the client side, not all connection URI options are supported or apply.
+## Example Usage
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{% choosable language typescript %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: nodejs
+config:
+    libvirt:uri:
+        value: qemu:///system
+
+```
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as libvirt from "@pulumi/libvirt";
+
+// Create a new domain
+const test1 = new libvirt.Domain("test1", {});
+```
+{{% /choosable %}}
+{{% choosable language python %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: python
+config:
+    libvirt:uri:
+        value: qemu:///system
+
+```
+```python
+import pulumi
+import pulumi_libvirt as libvirt
+
+# Create a new domain
+test1 = libvirt.Domain("test1")
+```
+{{% /choosable %}}
+{{% choosable language csharp %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: dotnet
+config:
+    libvirt:uri:
+        value: qemu:///system
+
+```
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Libvirt = Pulumi.Libvirt;
+
+return await Deployment.RunAsync(() =>
+{
+    // Create a new domain
+    var test1 = new Libvirt.Domain("test1");
+
+});
+
+```
+{{% /choosable %}}
+{{% choosable language go %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: go
+config:
+    libvirt:uri:
+        value: qemu:///system
+
+```
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Create a new domain
+		_, err := libvirt.NewDomain(ctx, "test1", nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+```
+{{% /choosable %}}
+{{% choosable language yaml %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: yaml
+config:
+    libvirt:uri:
+        value: qemu:///system
+
+```
+```yaml
+resources:
+  # Create a new domain
+  test1:
+    type: libvirt:Domain
+```
+{{% /choosable %}}
+{{% choosable language java %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: java
+config:
+    libvirt:uri:
+        value: qemu:///system
+
+```
+```java
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import com.pulumi.libvirt.Domain;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        // Create a new domain
+        var test1 = new Domain("test1");
+
+    }
+}
+```
+{{% /choosable %}}
+{{< /chooser >}}
+## Configuration Reference
+
+The following keys can be used to configure the provider.
+
+* `uri` - (Required) The [connection URI](https://libvirt.org/uri.html) used
+  to connect to the libvirt host.
+## Environment variables
+
+The libvirt connection URI can also be specified with the `LIBVIRT_DEFAULT_URI`
+shell environment variable.
+
+```
+$ export LIBVIRT_DEFAULT_URI="qemu+ssh://root@192.168.1.100/system"
+$ pulumi preview
+```

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -178,14 +178,42 @@ var metadata []byte
 var networkModesRegexp = regexp.MustCompile("- `[a-z]*`: ")
 
 func docRuleEdits(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
-	return append(defaults, tfbridge.DocsEdit{
-		Path: "network.markdown",
-		Edit: func(_ string, content []byte) ([]byte, error) {
-			return networkModesRegexp.ReplaceAllFunc(content,
-				func(src []byte) []byte {
-					return bytes.ReplaceAll(src,
-						[]byte("`"), []byte(`"`))
-				}), nil
+	return append(
+		defaults,
+		tfbridge.DocsEdit{
+			Path: "network.markdown",
+			Edit: func(_ string, content []byte) ([]byte, error) {
+				return networkModesRegexp.ReplaceAllFunc(content,
+					func(src []byte) []byte {
+						return bytes.ReplaceAll(src,
+							[]byte("`"), []byte(`"`))
+					}), nil
+			},
 		},
-	})
+		fixUpInstallationFileExample,
+		fixupBadHclTag,
+	)
+}
+
+var fixUpInstallationFileExample = targetedReplace(
+	"index.html.markdown",
+	[]byte(`resource "libvirt_domain" "test1" {
+  ...`),
+	[]byte(`resource "libvirt_domain" "test1" {
+  #...`),
+)
+
+var fixupBadHclTag = targetedReplace(
+	"index.html.markdown",
+	[]byte("shell environment variable.\n\n```hcl"),
+	[]byte("shell environment variable.\n\n```"),
+)
+
+func targetedReplace(filePath string, from, to []byte) tfbridge.DocsEdit {
+	return tfbridge.DocsEdit{
+		Path: filePath,
+		Edit: func(_ string, content []byte) ([]byte, error) {
+			return bytes.ReplaceAll(content, from, to), nil
+		},
+	}
 }


### PR DESCRIPTION
Part of pulumi/home#3598

Generates a single index.md file with relevant content.

This file was generated against a version of the plainDocsParser that runs provider-supplied editRules before code conversion, as several code blocks in the upstream docs caused an empty example and incorrect code choosers for what is a shell example. Depends on incoming bridge changes.

With added automation, this is blocked awaiting the next bridge release.
